### PR TITLE
Update runtime to 25.08, update shared-modules

### DIFF
--- a/com.supermodel3.Supermodel.yaml
+++ b/com.supermodel3.Supermodel.yaml
@@ -1,6 +1,6 @@
 id: com.supermodel3.Supermodel
 runtime: org.freedesktop.Platform
-runtime-version: "24.08"
+runtime-version: "25.08"
 sdk: org.freedesktop.Sdk
 command: supermodel
 separate-locales: false


### PR DESCRIPTION
Note: I assume this also needs SDL2 bundled with it, as it got removed from the runtime (unless sdl2-compat is sufficient).